### PR TITLE
gtksourceview: Lower max version

### DIFF
--- a/org.xfce.mousepad.yml
+++ b/org.xfce.mousepad.yml
@@ -39,7 +39,7 @@ modules:
           type: gnome
           name: gtksourceview
           versions:
-            <: 5.0.0
+            <: 4.99.0
 
   # optionnal dependencies (plugins)
   - name: gspell


### PR DESCRIPTION
This is required now, for some reason.

Related: #63